### PR TITLE
add VS Code and JetBrains IDE support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "html.customData": [
+        "./vscode.html-custom-data.json"
+    ]
+}

--- a/components.js
+++ b/components.js
@@ -1,0 +1,64 @@
+//
+// THIS FILE IS FOR DOCUMENTATION PURPOSES ONLY. 
+// THESE COMPONENTS ARE NOT FOR PRODUCTION USE.
+//
+
+
+/**
+ * @slot - This is a default/unnamed slot
+ *
+ * @summary This is a DCE Link
+ *
+ * @tag dce-link
+ */
+class DceLink extends HTMLElement {}
+
+customElements.define('dce-link', DceLink);
+
+/**
+ * @slot slot2 - You can put some elements here
+ *
+ * @summary This is a DCE with a slot
+ *
+ * @tag dce-2-slots
+ */
+class Dce2Slots extends HTMLElement {}
+
+customElements.define('dce-2-slots', Dce2Slots);
+
+/**
+ * @slot - This is a default/unnamed slot
+ *
+ * @summary This is a DCE with slots
+ *
+ * @tag dce-3-slot
+ */
+class Dce3Slot extends HTMLElement {}
+
+customElements.define('dce-3-slot', Dce3Slot);
+
+/**
+ * @slot - This replaces the start of the greeting
+ *
+ * @summary This is a DCE for greeting users
+ *
+ * @tag greet-element
+ */
+class GreetElement extends HTMLElement {}
+
+customElements.define('greet-element', GreetElement);
+
+
+/**
+ * @attribute {string} title - the name of the Pokemon
+ * @attribute {number} pokemon-id - the Pokemon's ID
+ * 
+ * @slot description - This replaces the Pokemon description
+ *
+ * @summary This is a DCE for displaying Pokemon
+ *
+ * @tag pokemon-tile
+ */
+class PokemonTile extends HTMLElement {}
+
+customElements.define('pokemon-tile', PokemonTile);

--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -1,0 +1,12 @@
+import { customElementVsCodePlugin } from "custom-element-vs-code-integration";
+import { customElementJetBrainsPlugin } from "custom-element-jet-brains-integration";
+
+export default {
+    /** Globs to analyze */
+    globs: ['components/*.js'],
+    /** Provide custom plugins */
+    plugins: [
+        customElementVsCodePlugin({ cssFileName: null }),
+        customElementJetBrainsPlugin({ packageJson: true })
+    ],
+  }

--- a/custom-elements-manifest.config.mjs
+++ b/custom-elements-manifest.config.mjs
@@ -3,7 +3,7 @@ import { customElementJetBrainsPlugin } from "custom-element-jet-brains-integrat
 
 export default {
     /** Globs to analyze */
-    globs: ['components/*.js'],
+    globs: ['components.js'],
     /** Provide custom plugins */
     plugins: [
         customElementVsCodePlugin({ cssFileName: null }),

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -4,7 +4,7 @@
   "modules": [
     {
       "kind": "javascript-module",
-      "path": "components/components.js",
+      "path": "components.js",
       "declarations": [
         {
           "kind": "class",
@@ -56,6 +56,56 @@
           "tagName": "dce-3-slot",
           "summary": "This is a DCE with slots",
           "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "GreetElement",
+          "slots": [
+            {
+              "description": "This replaces the start of the greeting",
+              "name": ""
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "greet-element",
+          "summary": "This is a DCE for greeting users",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "PokemonTile",
+          "slots": [
+            {
+              "description": "This replaces the Pokemon description",
+              "name": "description"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "the name of the Pokemon",
+              "name": "title"
+            },
+            {
+              "type": {
+                "text": "number"
+              },
+              "description": "the Pokemon's ID",
+              "name": "pokemon-id"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "pokemon-tile",
+          "summary": "This is a DCE for displaying Pokemon",
+          "customElement": true
         }
       ],
       "exports": [
@@ -64,7 +114,7 @@
           "name": "dce-link",
           "declaration": {
             "name": "DceLink",
-            "module": "components/components.js"
+            "module": "components.js"
           }
         },
         {
@@ -72,7 +122,7 @@
           "name": "dce-2-slots",
           "declaration": {
             "name": "Dce2Slots",
-            "module": "components/components.js"
+            "module": "components.js"
           }
         },
         {
@@ -80,7 +130,23 @@
           "name": "dce-3-slot",
           "declaration": {
             "name": "Dce3Slot",
-            "module": "components/components.js"
+            "module": "components.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "greet-element",
+          "declaration": {
+            "name": "GreetElement",
+            "module": "components.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "pokemon-tile",
+          "declaration": {
+            "name": "PokemonTile",
+            "module": "components.js"
           }
         }
       ]

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": "1.0.0",
+  "readme": "",
+  "modules": [
+    {
+      "kind": "javascript-module",
+      "path": "components/components.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "DceLink",
+          "slots": [
+            {
+              "description": "This is a default/unnamed slot",
+              "name": ""
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "dce-link",
+          "summary": "This is a DCE Link",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "Dce2Slots",
+          "slots": [
+            {
+              "description": "You can put some elements here",
+              "name": "slot2"
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "dce-2-slots",
+          "summary": "This is a DCE with a slot",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "Dce3Slot",
+          "slots": [
+            {
+              "description": "This is a default/unnamed slot",
+              "name": ""
+            }
+          ],
+          "superclass": {
+            "name": "HTMLElement"
+          },
+          "tagName": "dce-3-slot",
+          "summary": "This is a DCE with slots",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "dce-link",
+          "declaration": {
+            "name": "DceLink",
+            "module": "components/components.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "dce-2-slots",
+          "declaration": {
+            "name": "Dce2Slots",
+            "module": "components/components.js"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "dce-3-slot",
+          "declaration": {
+            "name": "Dce3Slot",
+            "module": "components/components.js"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,613 @@
             "name": "@epa-wg/custom-element",
             "version": "0.0.16",
             "license": "Apache-2.0",
+            "devDependencies": {
+                "@custom-elements-manifest/analyzer": "^0.9.2",
+                "custom-element-jet-brains-integration": "^1.4.3",
+                "custom-element-vs-code-integration": "^1.2.2"
+            },
             "funding": {
                 "type": "patreon",
                 "url": "https://www.patreon.com/sashafirsov"
             }
+        },
+        "node_modules/@custom-elements-manifest/analyzer": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.9.2.tgz",
+            "integrity": "sha512-E6OuKhtQvATUORveOZ0JifA9Rxf6hJ3do/rlG8h+wKFGOlY/eYoUGlq+o2/p4tOt0sTOt2MuzmdYOJ7qweeXwA==",
+            "dev": true,
+            "dependencies": {
+                "@custom-elements-manifest/find-dependencies": "^0.0.5",
+                "@github/catalyst": "^1.6.0",
+                "@web/config-loader": "0.1.3",
+                "chokidar": "3.5.2",
+                "command-line-args": "5.1.2",
+                "comment-parser": "1.2.4",
+                "custom-elements-manifest": "1.0.0",
+                "debounce": "1.2.1",
+                "globby": "11.0.4",
+                "typescript": "~4.3.2"
+            },
+            "bin": {
+                "cem": "cem.js",
+                "custom-elements-manifest": "cem.js"
+            }
+        },
+        "node_modules/@custom-elements-manifest/find-dependencies": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/find-dependencies/-/find-dependencies-0.0.5.tgz",
+            "integrity": "sha512-fKIMMZCDFSoL2ySUoz8knWgpV4jpb0lUXgLOvdZQMQFHxgxz1PqOJpUIypwvEVyKk3nEHRY4f10gNol02HjeCg==",
+            "dev": true,
+            "dependencies": {
+                "es-module-lexer": "^0.9.3"
+            }
+        },
+        "node_modules/@github/catalyst": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
+            "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
+            "dev": true
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@web/config-loader": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
+            "integrity": "sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^7.3.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/array-back": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.17"
+            }
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "dev": true,
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/command-line-args": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
+            "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
+            "dev": true,
+            "dependencies": {
+                "array-back": "^6.1.2",
+                "find-replace": "^3.0.0",
+                "lodash.camelcase": "^4.3.0",
+                "typical": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/comment-parser": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+            "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/custom-element-jet-brains-integration": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/custom-element-jet-brains-integration/-/custom-element-jet-brains-integration-1.4.3.tgz",
+            "integrity": "sha512-UMNI6/c5bO2lPlKpaYZHoiAMcmUdECT4BjIoBs0RLrBmBHGECoN+ppTVl9WLs4m/NUR70iXbTIYN6srXmC+m9w==",
+            "dev": true,
+            "dependencies": {
+                "prettier": "^2.8.0"
+            }
+        },
+        "node_modules/custom-element-vs-code-integration": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/custom-element-vs-code-integration/-/custom-element-vs-code-integration-1.2.2.tgz",
+            "integrity": "sha512-nts++86m/ujE4PZ8HSsxQ6a8ukrWF0J4LdCTFqCnErELCfCO+qozUDGcZ9Ufm5CnL7fYEygproFAZObEmJE8og==",
+            "dev": true,
+            "dependencies": {
+                "prettier": "^2.7.1"
+            }
+        },
+        "node_modules/custom-elements-manifest": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz",
+            "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
+            "dev": true
+        },
+        "node_modules/debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "dev": true
+        },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fastq": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+            "dev": true,
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-replace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "dev": true,
+            "dependencies": {
+                "array-back": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/find-replace/node_modules/array-back": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/globby": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "dev": true,
+            "dependencies": {
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/typical": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+            "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,55 +1,54 @@
 {
-    "name": "@epa-wg/custom-element",
-    "version": "0.0.16",
-    "description": "Declarative Custom Element as W3C proposal PoC with native(XSLT) based templating",
-    "browser": "custom-element.js",
-    "module": "custom-element.js",
-    "exports": {
-        ".": "./custom-element.js",
-        "./package.json": "./package.json",
-        "./CustomElement": "./custom-element.js"
-    },
-    "files": [
-        "*"
-    ],
-    "type": "module",
-    "types": "./custom-element.d.ts",
-    "scripts": {
-        "analyze": "cem analyze",
-        "dev:help": "echo \"needed for sandbox demo\"",
-        "dev": "npm run analyze && bash bin/stackblitz.sh",
-        "start": "npm i --no-save @web/dev-server && web-dev-server --node-resolve",
-        "test": "echo \"test would reside in https://github.com/EPA-WG/custom-element-test\" && exit 0",
-        "typings": "npx -p typescript tsc custom-element.js --declaration --allowJs --emitDeclarationOnly "
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/EPA-WG/custom-element.git"
-    },
-    "keywords": [
-        "WebComponent",
-        "Declarative Custom Element",
-        "XSLT",
-        "JS",
-        "javascript"
-    ],
-    "author": {
-        "name": "Sasha Firsov",
-        "email": "suns@simulationworks.com",
-        "url": "https://blog.firsov.net/"
-    },
-    "license": "Apache-2.0",
-    "bugs": {
-        "url": "https://github.com/EPA-WG/custom-element/issues"
-    },
-    "homepage": "https://github.com/EPA-WG/custom-element#readme",
-    "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/sashafirsov"
-    },
-    "devDependencies": {
-        "@custom-elements-manifest/analyzer": "^0.9.2",
-        "custom-element-jet-brains-integration": "^1.4.3",
-        "custom-element-vs-code-integration": "^1.2.2"
-    }
+  "name": "@epa-wg/custom-element",
+  "version": "0.0.16",
+  "description": "Declarative Custom Element as W3C proposal PoC with native(XSLT) based templating",
+  "browser": "custom-element.js",
+  "module": "custom-element.js",
+  "exports": {
+    ".": "./custom-element.js",
+    "./package.json": "./package.json",
+    "./CustomElement": "./custom-element.js"
+  },
+  "files": ["*"],
+  "type": "module",
+  "types": "./custom-element.d.ts",
+  "scripts": {
+    "analyze": "cem analyze",
+    "dev:help": "echo \"needed for sandbox demo\"",
+    "dev": "bash bin/stackblitz.sh",
+    "start": "npm i --no-save @web/dev-server && web-dev-server --node-resolve",
+    "test": "echo \"test would reside in https://github.com/EPA-WG/custom-element-test\" && exit 0",
+    "typings": "npx -p typescript tsc custom-element.js --declaration --allowJs --emitDeclarationOnly "
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/EPA-WG/custom-element.git"
+  },
+  "keywords": [
+    "WebComponent",
+    "Declarative Custom Element",
+    "XSLT",
+    "JS",
+    "javascript"
+  ],
+  "author": {
+    "name": "Sasha Firsov",
+    "email": "suns@simulationworks.com",
+    "url": "https://blog.firsov.net/"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/EPA-WG/custom-element/issues"
+  },
+  "homepage": "https://github.com/EPA-WG/custom-element#readme",
+  "funding": {
+    "type": "patreon",
+    "url": "https://www.patreon.com/sashafirsov"
+  },
+  "devDependencies": {
+    "@custom-elements-manifest/analyzer": "^0.9.2",
+    "custom-element-jet-brains-integration": "^1.4.3",
+    "custom-element-vs-code-integration": "^1.2.2"
+  },
+  "web-types": "./web-types.json"
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "type": "module",
     "types": "./custom-element.d.ts",
     "scripts": {
+        "analyze": "cem analyze",
         "dev:help": "echo \"needed for sandbox demo\"",
-        "dev": "bash bin/stackblitz.sh",
+        "dev": "npm run analyze && bash bin/stackblitz.sh",
         "start": "npm i --no-save @web/dev-server && web-dev-server --node-resolve",
         "test": "echo \"test would reside in https://github.com/EPA-WG/custom-element-test\" && exit 0",
         "typings": "npx -p typescript tsc custom-element.js --declaration --allowJs --emitDeclarationOnly "
@@ -45,5 +46,10 @@
     "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/sashafirsov"
+    },
+    "devDependencies": {
+        "@custom-elements-manifest/analyzer": "^0.9.2",
+        "custom-element-jet-brains-integration": "^1.4.3",
+        "custom-element-vs-code-integration": "^1.2.2"
     }
 }

--- a/vscode.html-custom-data.json
+++ b/vscode.html-custom-data.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vscode-html-languageservice/main/docs/customData.schema.json",
+  "version": 1.1,
+  "tags": [
+    {
+      "name": "dce-link",
+      "description": "This is a DCE Link\n---\n\n\n### **Slots:**\n - _default_ - This is a default/unnamed slot",
+      "attributes": [],
+      "references": []
+    },
+    {
+      "name": "dce-2-slots",
+      "description": "This is a DCE with a slot\n---\n\n\n### **Slots:**\n - **slot2** - You can put some elements here",
+      "attributes": [],
+      "references": []
+    },
+    {
+      "name": "dce-3-slot",
+      "description": "This is a DCE with slots\n---\n\n\n### **Slots:**\n - _default_ - This is a default/unnamed slot",
+      "attributes": [],
+      "references": []
+    }
+  ]
+}

--- a/vscode.html-custom-data.json
+++ b/vscode.html-custom-data.json
@@ -19,6 +19,29 @@
       "description": "This is a DCE with slots\n---\n\n\n### **Slots:**\n - _default_ - This is a default/unnamed slot",
       "attributes": [],
       "references": []
+    },
+    {
+      "name": "greet-element",
+      "description": "This is a DCE for greeting users\n---\n\n\n### **Slots:**\n - _default_ - This replaces the start of the greeting",
+      "attributes": [],
+      "references": []
+    },
+    {
+      "name": "pokemon-tile",
+      "description": "This is a DCE for displaying Pokemon\n---\n\n\n### **Slots:**\n - **description** - This replaces the Pokemon description",
+      "attributes": [
+        {
+          "name": "title",
+          "description": "the name of the Pokemon",
+          "values": []
+        },
+        {
+          "name": "pokemon-id",
+          "description": "the Pokemon's ID",
+          "values": []
+        }
+      ],
+      "references": []
     }
   ]
 }

--- a/web-types.json
+++ b/web-types.json
@@ -38,6 +38,59 @@
           ],
           "events": [],
           "js": { "properties": [], "events": [] }
+        },
+        {
+          "name": "greet-element",
+          "description": "This is a DCE for greeting users\n---\n\n\n### **Slots:**\n - _default_ - This replaces the start of the greeting",
+          "doc-url": "",
+          "attributes": [],
+          "slots": [
+            {
+              "name": "",
+              "description": "This replaces the start of the greeting"
+            }
+          ],
+          "events": [],
+          "js": { "properties": [], "events": [] }
+        },
+        {
+          "name": "pokemon-tile",
+          "description": "This is a DCE for displaying Pokemon\n---\n\n\n### **Slots:**\n - **description** - This replaces the Pokemon description",
+          "doc-url": "",
+          "attributes": [
+            {
+              "name": "title",
+              "description": "the name of the Pokemon",
+              "value": { "type": "string" }
+            },
+            {
+              "name": "pokemon-id",
+              "description": "the Pokemon's ID",
+              "value": { "type": "number" }
+            }
+          ],
+          "slots": [
+            {
+              "name": "description",
+              "description": "This replaces the Pokemon description"
+            }
+          ],
+          "events": [],
+          "js": {
+            "properties": [
+              {
+                "name": "title",
+                "description": "the name of the Pokemon",
+                "value": { "type": "string" }
+              },
+              {
+                "name": "pokemon-id",
+                "description": "the Pokemon's ID",
+                "value": { "type": "number" }
+              }
+            ],
+            "events": []
+          }
         }
       ]
     },

--- a/web-types.json
+++ b/web-types.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JetBrains/web-types/master/schema/web-types.json",
+  "name": "@epa-wg/custom-element",
+  "version": "0.0.16",
+  "description-markup": "markdown",
+  "contributions": {
+    "html": {
+      "elements": [
+        {
+          "name": "dce-link",
+          "description": "This is a DCE Link\n---\n\n\n### **Slots:**\n - _default_ - This is a default/unnamed slot",
+          "doc-url": "",
+          "attributes": [],
+          "slots": [
+            { "name": "", "description": "This is a default/unnamed slot" }
+          ],
+          "events": [],
+          "js": { "properties": [], "events": [] }
+        },
+        {
+          "name": "dce-2-slots",
+          "description": "This is a DCE with a slot\n---\n\n\n### **Slots:**\n - **slot2** - You can put some elements here",
+          "doc-url": "",
+          "attributes": [],
+          "slots": [
+            { "name": "slot2", "description": "You can put some elements here" }
+          ],
+          "events": [],
+          "js": { "properties": [], "events": [] }
+        },
+        {
+          "name": "dce-3-slot",
+          "description": "This is a DCE with slots\n---\n\n\n### **Slots:**\n - _default_ - This is a default/unnamed slot",
+          "doc-url": "",
+          "attributes": [],
+          "slots": [
+            { "name": "", "description": "This is a default/unnamed slot" }
+          ],
+          "events": [],
+          "js": { "properties": [], "events": [] }
+        }
+      ]
+    },
+    "css": {
+      "properties": [],
+      "pseudo-elements": []
+    }
+  }
+}


### PR DESCRIPTION
This is a simple demonstration of how to add IDE support for DCEs. 

This PR includes the [CEM/Analyzer](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/) as well as plugins to generate the needed files [VS Code](https://www.npmjs.com/package/custom-element-vs-code-integration) and [JetBrains IDE](https://www.npmjs.com/package/custom-element-jet-brains-integration) support.

The component definitions are in the `components.js` file. these are for documentation purposes only and shouldn't be used in production (also, they are necessary since you are using DCEs).

To generate the necessary config files for the editors, run `npm run analyze`. This will generate the `vscode.html-custom-data.json` and `web-types.json`.